### PR TITLE
(feat) add new findAll that returns a List

### DIFF
--- a/src/main/java/th/co/geniustree/springdata/jpa/repository/JpaSpecificationExecutorWithProjection.java
+++ b/src/main/java/th/co/geniustree/springdata/jpa/repository/JpaSpecificationExecutorWithProjection.java
@@ -2,11 +2,13 @@ package th.co.geniustree.springdata.jpa.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.repository.NoRepositoryBean;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,6 +18,10 @@ import java.util.Optional;
 public interface JpaSpecificationExecutorWithProjection<T> {
 
     <R> Optional<R> findOne(Specification<T> spec, Class<R> projectionClass);
+
+    <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass);
+
+    <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass, Sort sort);
 
     <R> Page<R> findAll(Specification<T> spec, Class<R> projectionClass, Pageable pageable);
 

--- a/src/main/java/th/co/geniustree/springdata/jpa/repository/support/JpaSpecificationExecutorWithProjectionImpl.java
+++ b/src/main/java/th/co/geniustree/springdata/jpa/repository/support/JpaSpecificationExecutorWithProjectionImpl.java
@@ -84,6 +84,19 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
     }
 
     @Override
+    public <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass) {
+        return findAll(spec, projectionClass, Sort.unsorted());
+    }
+
+    @Override
+    public <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass, Sort sort) {
+        final ReturnedType returnedType = ReturnTypeWarpper.of(projectionClass, getDomainClass(), projectionFactory);
+        final TypedQuery<Tuple> query = getTupleQuery(spec, sort, returnedType);
+        final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory,returnedType);
+        return resultProcessor.processResult(query.getResultList(), new TupleConverter(returnedType));
+    }
+
+    @Override
     public <R> Page<R> findAll(Specification<T> spec, Class<R> projectionType, Pageable pageable) {
         final ReturnedType returnedType = ReturnTypeWarpper.of(projectionType, getDomainClass(), projectionFactory);
         final TypedQuery<Tuple> query = getTupleQuery(spec, pageable.isPaged() ? pageable.getSort() : Sort.unsorted(), returnedType);

--- a/src/test/java/th/co/geniustree/springdata/jpa/SpecificationExecutorProjectionTest.java
+++ b/src/test/java/th/co/geniustree/springdata/jpa/SpecificationExecutorProjectionTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import th.co.geniustree.springdata.jpa.domain.Document;
 import th.co.geniustree.springdata.jpa.repository.DocumentRepository;
 import th.co.geniustree.springdata.jpa.specification.DocumentSpecs;
 
+import java.util.List;
 import java.util.Optional;
 
 @RunWith(SpringRunner.class)
@@ -65,6 +67,23 @@ public class SpecificationExecutorProjectionTest {
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getParent().getId()).isEqualTo(13L);
     }
+
+    @Test
+    public void findAll_List_Unsorted() {
+        Specification<Document> where = Specification.where(null);
+        List<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(where, DocumentRepository.DocumentWithoutParent.class);
+        Assertions.assertThat(all).isNotEmpty();
+        Assertions.assertThat(all.size()).isEqualTo(24);
+    }
+
+    @Test
+    public void findAll_List_Sorted() {
+        Specification<Document> where = Specification.where(null);
+        List<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(where, DocumentRepository.DocumentWithoutParent.class, Sort.by(Sort.Order.desc("id")));
+        Assertions.assertThat(all).isNotEmpty();
+        Assertions.assertThat(all.get(0).getId()).isEqualTo(24L);
+    }
+
     @Test
     public void find_single_page() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(24L));


### PR DESCRIPTION
this makes it possible to call findAll method with just the spec and the
projection class. And the method will return a List of your Projection
instead of a Page. Fixes pramoth/specification-with-projection#16